### PR TITLE
Fill out pack command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 /tmp
 /.vscode
 /colliderrc.toml
+/collider-out
+/package-lock.json
+/node_modules

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,9 @@ dependencies = [
  "collider-command",
  "collider-common",
  "collider-electron",
+ "flate2",
  "fs_extra",
+ "tar",
  "which",
 ]
 
@@ -948,6 +950,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b394ed3d285a429378d3b384b9eb1285267e7df4b166df24b7a6939a04dc392e"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "winapi",
 ]
 
 [[package]]
@@ -2627,6 +2641,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f5515d3add52e0bbdcad7b83c388bb36ba7b754dda3b5f5bc2d38640cdba5c"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3225,6 +3250,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16cdb3898397cf7f624c294948669beafaeebc5577d5ec53d0afb76633593597"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "xattr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,6 +528,7 @@ dependencies = [
  "collider-command",
  "collider-common",
  "collider-electron",
+ "which",
 ]
 
 [[package]]
@@ -892,6 +893,12 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "electron-collider"
@@ -3157,6 +3164,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "which"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
+dependencies = [
+ "either",
+ "lazy_static 1.4.0",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,9 +528,7 @@ dependencies = [
  "collider-command",
  "collider-common",
  "collider-electron",
- "flate2",
  "fs_extra",
- "tar",
  "which",
 ]
 
@@ -950,18 +948,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b394ed3d285a429378d3b384b9eb1285267e7df4b166df24b7a6939a04dc392e"
 dependencies = [
  "instant",
-]
-
-[[package]]
-name = "filetime"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "redox_syscall",
- "winapi",
 ]
 
 [[package]]
@@ -2641,17 +2627,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tar"
-version = "0.4.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f5515d3add52e0bbdcad7b83c388bb36ba7b754dda3b5f5bc2d38640cdba5c"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3250,15 +3225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16cdb3898397cf7f624c294948669beafaeebc5577d5ec53d0afb76633593597"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "xattr"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,6 +528,9 @@ dependencies = [
  "collider-command",
  "collider-common",
  "collider-electron",
+ "flate2",
+ "fs_extra",
+ "tar",
  "which",
 ]
 
@@ -947,6 +950,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b394ed3d285a429378d3b384b9eb1285267e7df4b166df24b7a6939a04dc392e"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "winapi",
 ]
 
 [[package]]
@@ -2626,6 +2641,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f5515d3add52e0bbdcad7b83c388bb36ba7b754dda3b5f5bc2d38640cdba5c"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3224,6 +3250,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16cdb3898397cf7f624c294948669beafaeebc5577d5ec53d0afb76633593597"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "xattr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/commands/collider-cmd-pack/Cargo.toml
+++ b/commands/collider-cmd-pack/Cargo.toml
@@ -8,3 +8,5 @@ edition = "2018"
 collider-command = { path = "../../crates/collider-command" }
 collider-common = { path = "../../crates/collider-common" }
 collider-electron = { path = "../../crates/collider-electron" }
+
+which = "4.2.2"

--- a/commands/collider-cmd-pack/Cargo.toml
+++ b/commands/collider-cmd-pack/Cargo.toml
@@ -9,7 +9,5 @@ collider-command = { path = "../../crates/collider-command" }
 collider-common = { path = "../../crates/collider-common" }
 collider-electron = { path = "../../crates/collider-electron" }
 
-flate2 = "1.0.14"
 fs_extra = "1.2.0"
-tar = "0.4.37"
 which = "4.2.2"

--- a/commands/collider-cmd-pack/Cargo.toml
+++ b/commands/collider-cmd-pack/Cargo.toml
@@ -9,4 +9,7 @@ collider-command = { path = "../../crates/collider-command" }
 collider-common = { path = "../../crates/collider-common" }
 collider-electron = { path = "../../crates/collider-electron" }
 
+flate2 = "1.0.14"
+fs_extra = "1.2.0"
+tar = "0.4.37"
 which = "4.2.2"

--- a/commands/collider-cmd-pack/Cargo.toml
+++ b/commands/collider-cmd-pack/Cargo.toml
@@ -9,5 +9,7 @@ collider-command = { path = "../../crates/collider-command" }
 collider-common = { path = "../../crates/collider-common" }
 collider-electron = { path = "../../crates/collider-electron" }
 
+flate2 = "1.0.14"
 fs_extra = "1.2.0"
+tar = "0.4.37"
 which = "4.2.2"

--- a/commands/collider-cmd-pack/src/app.rs
+++ b/commands/collider-cmd-pack/src/app.rs
@@ -1,0 +1,9 @@
+use collider_electron::Electron;
+
+#[derive(Debug)]
+pub struct App {
+    release: Electron,
+}
+
+#[derive(Debug, Clone)]
+pub struct AppBuilder {}

--- a/commands/collider-cmd-pack/src/app.rs
+++ b/commands/collider-cmd-pack/src/app.rs
@@ -1,9 +1,0 @@
-use collider_electron::Electron;
-
-#[derive(Debug)]
-pub struct App {
-    release: Electron,
-}
-
-#[derive(Debug, Clone)]
-pub struct AppBuilder {}

--- a/commands/collider-cmd-pack/src/lib.rs
+++ b/commands/collider-cmd-pack/src/lib.rs
@@ -8,11 +8,9 @@ use collider_command::{
 };
 use collider_common::{
     miette::{self, Context, IntoDiagnostic, Result},
-    smol::{self, fs, process::Command},
+    smol::{fs, process::Command},
 };
 use collider_electron::{Electron, ElectronOpts};
-use flate2::read::GzDecoder;
-use tar::Archive;
 
 #[derive(Debug, Clap, ColliderConfigLayer)]
 pub struct PackCmd {
@@ -84,14 +82,46 @@ impl PackCmd {
             .file_name()
             .expect("BUG: This should have a file name.");
         let build_dir = out.join("electron-builds").join(dirname);
-        let proj_dir = build_dir.join("project");
         let copied_electron = electron.copy_files(&build_dir.join("release")).await?;
-        self.stage_proj(&self.path, &proj_dir).await?;
-        self.rebuild(&copied_electron).await?;
+        self.prune_proj(&self.path).await?;
+        self.rebuild_proj(&self.path, &copied_electron).await?;
         Ok(copied_electron)
     }
 
-    async fn rebuild(&self, electron: &Electron) -> Result<()> {
+    async fn prune_proj(&self, proj_dir: &Path) -> Result<()> {
+        tracing::info!("Pruning current node_modules down to only production dependencies.");
+        let npm_path = which::which("npm").into_diagnostic().context(
+            "Failed to find npm command while packaging project. NPM/npx are required by collider.",
+        )?;
+
+        let mut cmd = if cfg!(target_os = "windows") {
+            let mut cmd = Command::new("cmd");
+            cmd.arg("/c");
+            cmd.arg(npm_path);
+            cmd
+        } else {
+            Command::new(npm_path)
+        };
+
+        let status = cmd
+            .arg("prune")
+            .arg("--omit")
+            .arg("dev")
+            .arg("--quiet")
+            .current_dir(proj_dir)
+            .status()
+            .await
+            .into_diagnostic()
+            .context("Failed to spawn NPM itself.")?;
+
+        if !status.success() {
+            miette::bail!("node_modules pruning failed.")
+        }
+
+        Ok(())
+    }
+
+    async fn rebuild_proj(&self, proj_dir: &Path, electron: &Electron) -> Result<()> {
         tracing::info!("Rebuilding node_modules for target platform.");
         let npx_path = which::which("npx").into_diagnostic().context(
             "Failed to find npx command while packaging project. NPM/npx are required by collider.",
@@ -112,117 +142,14 @@ impl PackCmd {
             .arg(electron.arch())
             .arg("--platform")
             .arg(electron.os())
-            .current_dir(&self.path)
+            .current_dir(proj_dir)
             .status()
             .await
             .into_diagnostic()
-            .context("Executing npx Command itself failed.")?;
-
-        if status.success() {
-            Ok(())
-        } else {
-            miette::bail!("node_modules rebuild failed.")
-        }
-    }
-
-    async fn stage_proj(&self, from: &Path, to: &Path) -> Result<()> {
-        tracing::info!("Staging current app before packaging");
-        let npm_path = which::which("npm").into_diagnostic().context(
-            "Failed to find npm command while packaging project. NPM/npx are required by collider.",
-        )?;
-        tracing::debug!("npm path: {}", npm_path.display());
-
-        // First, we stage the current app into the staging folder by packing
-        // it and re-extracting it. This gets rid of unneeded crud.
-        tracing::debug!("Packing Electron project at {}", from.display());
-        let mut cmd = if cfg!(target_os = "windows") {
-            let mut cmd = Command::new("cmd");
-            cmd.arg("/c");
-            cmd.arg(&npm_path);
-            cmd
-        } else {
-            Command::new(&npm_path)
-        };
-        let output = cmd
-            .arg("pack")
-            .current_dir(from)
-            .output()
-            .await
-            .into_diagnostic()
-            .context("Spawning npm pack Command itself failed.")?;
-
-        if !output.status.success() {
-            miette::bail!("packing app for staging failed.")
-        }
-
-        // Now that we packed, we need to extract the tarball into the staging directory and remove the tarball.
-        let tarball_name = String::from_utf8(output.stdout)
-            .into_diagnostic()
-            .context("Failed to parse staging tarball filename as utf8. This is probably a bug in NPM itself.")?;
-        let tarball = from.join(&tarball_name.trim());
-        let to_clone = to.to_owned();
-        tracing::debug!(
-            "Extracting packed NPM project from {} to {}",
-            tarball.display(),
-            to.display()
-        );
-        smol::unblock(move || {
-            // TODO: error handling
-            let mut ar = Archive::new(GzDecoder::new(
-                std::fs::File::open(&tarball).expect("BUG: Where did the tarball go?"),
-            ));
-            ar.unpack(&to_clone)
-        })
-        .await
-        .into_diagnostic()
-        .context("Failed to extract staging tarball.")?;
-
-        let from_nm = from.join("node_modules");
-        let to_nm = to.join("node_modules");
-        tracing::debug!(
-            "Copying node_modules folder from {} to {}",
-            from_nm.display(),
-            to_nm.display()
-        );
-        fs::create_dir_all(&to_nm)
-            .await
-            .into_diagnostic()
-            .context("Failed to create destination directory for copied node_modules in staging")?;
-        smol::unblock(move || {
-            let mut opts = fs_extra::dir::CopyOptions::new();
-            opts.overwrite = true;
-            opts.content_only = true;
-            fs_extra::dir::copy(from_nm, to_nm, &opts)
-        })
-        .await
-        .into_diagnostic()
-        .context("Failed to copy over node_modules")?;
-
-        // Once we've moved node_modules, we do a prune and a rebuild.
-        tracing::debug!(
-            "Pruning node_modules directory at {}",
-            to.join("node_modules").display()
-        );
-        let mut cmd = if cfg!(target_os = "windows") {
-            let mut cmd = Command::new("cmd");
-            cmd.arg("/c");
-            cmd.arg(&npm_path);
-            cmd
-        } else {
-            Command::new(&npm_path)
-        };
-        let status = cmd
-            .arg("prune")
-            .arg("--omit")
-            .arg("dev")
-            .current_dir(to)
-            .status()
-            .await
-            .into_diagnostic()
-            .context("Spawning npm Command itself failed.")?;
+            .context("Failed to spawn npx itself.")?;
 
         if !status.success() {
-            miette::bail!("pruning staging folder failed.")
+            miette::bail!("node_modules rebuild failed.")
         }
 
         Ok(())

--- a/commands/collider-cmd-pack/src/lib.rs
+++ b/commands/collider-cmd-pack/src/lib.rs
@@ -15,7 +15,7 @@ use collider_electron::{Electron, ElectronOpts};
 #[derive(Debug, Clap, ColliderConfigLayer)]
 pub struct PackCmd {
     #[clap(
-        about = "Path to Electron app. Must be an index.js file, a folder containing a package.json file, or a folder containing an index.json file, and .html/.htm file. URLs are not supported by this tool.",
+        about = "Path to the root of an Electron app. Must be a directory containing a package.json and any files you want to bundle into the app.",
         default_value = "."
     )]
     path: PathBuf,
@@ -27,6 +27,13 @@ pub struct PackCmd {
         long
     )]
     output: PathBuf,
+
+    #[clap(
+        about = "Path to a prebuilt ASAR file. By default, Collider will build it for you.",
+        short,
+        long
+    )]
+    asar: Option<PathBuf>,
 
     #[clap(long, short, about = "Force download of the Electron binary.")]
     force: bool,
@@ -52,18 +59,27 @@ pub struct PackCmd {
 impl ColliderCommand for PackCmd {
     async fn execute(self) -> Result<()> {
         let out = self.output.clone();
+        // Make sure we've downloaded & cached an electron version
+        let electron = self.ensure_electron().await?;
+        let asar = self.ensure_asar(self.asar.as_deref()).await?;
         fs::create_dir_all(&out)
             .await
             .into_diagnostic()
             .context("Failed to create output directory")?;
 
-        let electron = self.ensure_electron(&out).await?;
         println!("{:#?}", electron);
         Ok(())
     }
 }
 
 impl PackCmd {
+    async fn ensure_asar(&self, asar: Option<&Path>) -> Result<PathBuf> {
+        if let Some(asar) = asar {
+            return Ok(asar);
+        }
+
+    }
+
     async fn ensure_electron(&self, out: &Path) -> Result<Electron> {
         let mut opts = ElectronOpts::new()
             .force(self.force)
@@ -81,19 +97,43 @@ impl PackCmd {
         let dirname = electron_dir
             .file_name()
             .expect("BUG: This should have a file name.");
-        let build_dir = out.join("electron-builds").join(dirname);
+        let build_dir = out.join(dirname);
         let copied_electron = electron.copy_files(&build_dir.join("release")).await?;
-        self.prune_proj(&self.path).await?;
-        self.rebuild_proj(&self.path, &copied_electron).await?;
+        self.remove_default_app_asar(&copied_electron).await?;
+        let asar_dest = build_dir.join("release").join("resources").join("app.asar");
+        if let Some(asar) = &self.asar {
+            // TODO: Copy over .asar
+            let opts = fs_extra::file::CopyOptions::new();
+            fs_extra::file::copy(asar, &asar_dest, &opts).into_diagnostic()?;
+        } else {
+            self.prune_proj(&self.path).await?;
+            self.rebuild_proj(&self.path, &copied_electron).await?;
+            self.pack_asar(&self.path, &asar_dest).await?;
+        }
         Ok(copied_electron)
+    }
+
+    async fn remove_default_app_asar(&self, electron: &Electron) -> Result<()> {
+        let default_app = electron
+            .exe()
+            .parent()
+            .expect("BUG: This should have a parent directory.")
+            .join("resources")
+            .join("default_app.asar");
+        fs::remove_file(&default_app).await.into_diagnostic()?;
+        Ok(())
     }
 
     async fn prune_proj(&self, proj_dir: &Path) -> Result<()> {
         tracing::info!("Pruning current node_modules down to only production dependencies.");
+        // TODO: Instead of doing this, get a direct path to the npm-cli.js
+        // file. This will help bypass the Terminate Batch Job b.s. on
+        // Windows.
         let npm_path = which::which("npm").into_diagnostic().context(
             "Failed to find npm command while packaging project. NPM/npx are required by collider.",
         )?;
 
+        // TODO: pnpm and Yarn support. See https://github.com/zkochan/which-pm. For now, just use NPM :)
         let mut cmd = if cfg!(target_os = "windows") {
             let mut cmd = Command::new("cmd");
             cmd.arg("/c");
@@ -104,10 +144,8 @@ impl PackCmd {
         };
 
         let status = cmd
-            .arg("prune")
-            .arg("--omit")
-            .arg("dev")
-            .arg("--quiet")
+            .arg("install")
+            .arg("--production")
             .current_dir(proj_dir)
             .status()
             .await
@@ -150,6 +188,39 @@ impl PackCmd {
 
         if !status.success() {
             miette::bail!("node_modules rebuild failed.")
+        }
+
+        Ok(())
+    }
+
+    async fn pack_asar(&self, proj_dir: &Path, dest: &Path) -> Result<()> {
+        tracing::info!("Rebuilding node_modules for target platform.");
+        let npx_path = which::which("npx").into_diagnostic().context(
+            "Failed to find npx command while packaging project. NPM/npx are required by collider.",
+        )?;
+
+        let mut cmd = if cfg!(target_os = "windows") {
+            let mut cmd = Command::new("cmd");
+            cmd.arg("/c");
+            cmd.arg(npx_path);
+            cmd
+        } else {
+            Command::new(npx_path)
+        };
+
+        let status = cmd
+            .arg("asar")
+            .arg("pack")
+            .arg(proj_dir)
+            .arg(dest)
+            .current_dir(proj_dir)
+            .status()
+            .await
+            .into_diagnostic()
+            .context("Failed to spawn npx itself.")?;
+
+        if !status.success() {
+            miette::bail!("Packaging up .asar failed.")
         }
 
         Ok(())

--- a/commands/collider-cmd-pack/src/lib.rs
+++ b/commands/collider-cmd-pack/src/lib.rs
@@ -1,17 +1,49 @@
+use std::path::PathBuf;
+
 use collider_command::{
     async_trait::async_trait,
     clap::{self, Clap},
     collider_config::{self, ColliderConfigLayer},
-    tracing, ColliderCommand,
+    ColliderCommand,
 };
-use collider_common::miette::Result;
+use collider_common::{
+    miette::{Context, IntoDiagnostic, Result},
+    smol::fs,
+};
+use collider_electron::{Electron, ElectronOpts};
 
 #[derive(Debug, Clap, ColliderConfigLayer)]
 pub struct PackCmd {
-    #[clap(from_global)]
-    verbosity: tracing::Level,
+    #[clap(
+        about = "Path to Electron app. Must be an index.js file, a folder containing a package.json file, a folder containing an index.json file, and .html/.htm file, or an http/https/file URL.",
+        default_value = "."
+    )]
+    path: String,
+
+    #[clap(
+        about = "Directory to write packaged output files to.",
+        default_value = "collider-out",
+        short,
+        long
+    )]
+    output: PathBuf,
+
+    #[clap(long, short, about = "Force download of the Electron binary.")]
+    force: bool,
+
+    #[clap(
+        long,
+        short = 'p',
+        about = "Include prerelease versions when trying to find a version match."
+    )]
+    include_prerelease: bool,
+
+    #[clap(long, short, about = "GitHub API Token (no permissions needed)")]
+    github_token: Option<String>,
+
     #[clap(from_global)]
     quiet: bool,
+
     #[clap(from_global)]
     json: bool,
 }
@@ -19,7 +51,38 @@ pub struct PackCmd {
 #[async_trait]
 impl ColliderCommand for PackCmd {
     async fn execute(self) -> Result<()> {
-        println!("Packaging app for release.");
+        let out = self.output.clone();
+        fs::create_dir_all(&out)
+            .await
+            .into_diagnostic()
+            .context("Failed to create output directory")?;
+
+        let electron = self.ensure_electron().await?;
+        let electron_dir = electron
+            .exe()
+            .parent()
+            .expect("BUG: This should definitely have a parent directory.")
+            .to_owned();
+        let dirname = electron_dir
+            .file_name()
+            .expect("BUG: This should have a file name.");
+        let build_dir = out.join("electron-builds").join(dirname);
+        let copied_electron = electron.copy_files(&build_dir).await?;
+
         Ok(())
+    }
+}
+
+impl PackCmd {
+    async fn ensure_electron(&self) -> Result<Electron> {
+        let mut opts = ElectronOpts::new()
+            .force(self.force)
+            .include_prerelease(self.include_prerelease);
+        if let Some(token) = &self.github_token {
+            opts = opts.github_token(token.to_owned());
+        }
+
+        let electron = opts.ensure_electron().await?;
+        Ok(electron)
     }
 }

--- a/commands/collider-cmd-pack/src/lib.rs
+++ b/commands/collider-cmd-pack/src/lib.rs
@@ -8,9 +8,11 @@ use collider_command::{
 };
 use collider_common::{
     miette::{self, Context, IntoDiagnostic, Result},
-    smol::{fs, process::Command},
+    smol::{self, fs, process::Command},
 };
 use collider_electron::{Electron, ElectronOpts};
+use flate2::read::GzDecoder;
+use tar::Archive;
 
 #[derive(Debug, Clap, ColliderConfigLayer)]
 pub struct PackCmd {
@@ -61,27 +63,85 @@ impl ColliderCommand for PackCmd {
         let out = self.output.clone();
         // Make sure we've downloaded & cached an electron version
         let electron = self.ensure_electron().await?;
-        let asar = self.ensure_asar(&electron).await?;
         fs::create_dir_all(&out)
             .await
             .into_diagnostic()
             .context("Failed to create output directory")?;
-        let rel_electron = self.prepare_release(&electron, &asar, &out).await?;
+        let (build_dir, rel_electron) = self.ensure_build_dir(&electron, &out).await?;
+        let asar = self.ensure_asar(&rel_electron, &build_dir).await?;
+        self.place_asar(
+            &rel_electron,
+            &asar,
+            &build_dir.join("release").join("resources").join("app.asar"),
+        )
+        .await?;
         println!("{:#?}", rel_electron);
         Ok(())
     }
 }
 
 impl PackCmd {
-    async fn ensure_asar(&self, electron: &Electron) -> Result<PathBuf> {
+    async fn ensure_asar(&self, electron: &Electron, build_dir: &Path) -> Result<PathBuf> {
         if let Some(asar) = &self.asar {
             return Ok(asar.clone());
         }
-        self.prune_proj(&self.path).await?;
-        self.rebuild_proj(&self.path, electron).await?;
-        let asar_dest = self.path.join("node_modules").join("app.asar");
-        self.pack_asar(&self.path, &asar_dest).await?;
+        // TODO: npm pack the project up, extract it into the build dir, `npm
+        // i --production` it, then continue with the rest here.
+        let tarball = self.npm_pack_proj(&self.path).await?;
+        let proj_dest = self.extract_to_build_dir(&tarball, build_dir).await?;
+        self.prune_proj(&proj_dest).await?;
+        self.rebuild_proj(&proj_dest, electron).await?;
+        let asar_dest = build_dir.join("app.asar");
+        self.pack_asar(&proj_dest, &asar_dest).await?;
         Ok(asar_dest)
+    }
+
+    async fn npm_pack_proj(&self, proj_dir: &Path) -> Result<PathBuf> {
+        let npm_path = which::which("npm").into_diagnostic().context(
+            "Failed to find npm command while packaging project. NPM/npx are required by collider.",
+        )?;
+
+        // TODO: pnpm and Yarn support. See https://github.com/zkochan/which-pm. For now, just use NPM :)
+        let mut cmd = if cfg!(target_os = "windows") {
+            let mut cmd = Command::new("cmd");
+            cmd.arg("/c");
+            cmd.arg(npm_path);
+            cmd
+        } else {
+            Command::new(npm_path)
+        };
+
+        let output = cmd
+            .arg("pack")
+            .output()
+            .await
+            .into_diagnostic()
+            .context("Failed to spawn NPM")?;
+
+        if !output.status.success() {
+            miette::bail!("NPM pack failed")
+        }
+
+        let package_file = String::from_utf8(output.stdout)
+            .into_diagnostic()
+            .context("Package name is invalid utf8")?;
+
+        Ok(proj_dir.join(&package_file.trim()))
+    }
+
+    async fn extract_to_build_dir(&self, tarball: &Path, build_dir: &Path) -> Result<PathBuf> {
+        let tarball_clone = tarball.to_owned();
+        let build_dir_clone = build_dir.to_owned();
+        smol::unblock(move || {
+            let mut archive = Archive::new(GzDecoder::new(
+                std::fs::File::open(&tarball_clone).expect("Opening the tarball failed?"),
+            ));
+            archive.unpack(&build_dir_clone)
+        })
+        .await
+        .into_diagnostic()
+        .context("Failed to extract build tarball to staging area")?;
+        Ok(build_dir.join("package"))
     }
 
     async fn ensure_electron(&self) -> Result<Electron> {
@@ -96,12 +156,11 @@ impl PackCmd {
         Ok(electron)
     }
 
-    async fn prepare_release(
+    async fn ensure_build_dir(
         &self,
         electron: &Electron,
-        asar: &Path,
         out: &Path,
-    ) -> Result<Electron> {
+    ) -> Result<(PathBuf, Electron)> {
         let electron_dir = electron
             .exe()
             .parent()
@@ -111,12 +170,20 @@ impl PackCmd {
             .file_name()
             .expect("BUG: This should have a file name.");
         let build_dir = out.join(dirname);
-        let copied_electron = electron.copy_files(&build_dir.join("release")).await?;
-        self.remove_default_app_asar(&copied_electron).await?;
-        let asar_dest = build_dir.join("release").join("resources").join("app.asar");
+        let new_electron = electron.copy_files(&build_dir.join("release")).await?;
+        Ok((build_dir, new_electron))
+    }
+
+    async fn place_asar(&self, electron: &Electron, asar: &Path, dest: &Path) -> Result<()> {
+        self.remove_default_app_asar(electron).await?;
+        tracing::debug!(
+            "Copying .asar from {} to {}",
+            asar.display(),
+            dest.display()
+        );
         let opts = fs_extra::file::CopyOptions::new();
-        fs_extra::file::copy(asar, &asar_dest, &opts).into_diagnostic()?;
-        Ok(copied_electron)
+        fs_extra::file::copy(asar, &dest, &opts).into_diagnostic()?;
+        Ok(())
     }
 
     async fn remove_default_app_asar(&self, electron: &Electron) -> Result<()> {
@@ -200,6 +267,11 @@ impl PackCmd {
     }
 
     async fn pack_asar(&self, proj_dir: &Path, dest: &Path) -> Result<()> {
+        self.run_asar_pack(proj_dir, dest).await?;
+        Ok(())
+    }
+
+    async fn run_asar_pack(&self, proj_dir: &Path, dest: &Path) -> Result<()> {
         tracing::info!("Rebuilding node_modules for target platform.");
         let npx_path = which::which("npx").into_diagnostic().context(
             "Failed to find npx command while packaging project. NPM/npx are required by collider.",
@@ -219,7 +291,7 @@ impl PackCmd {
             .arg("pack")
             .arg(proj_dir)
             .arg(dest)
-            .current_dir(proj_dir)
+            .current_dir(&self.path)
             .status()
             .await
             .into_diagnostic()

--- a/commands/collider-cmd-pack/src/lib.rs
+++ b/commands/collider-cmd-pack/src/lib.rs
@@ -4,21 +4,21 @@ use collider_command::{
     async_trait::async_trait,
     clap::{self, Clap},
     collider_config::{self, ColliderConfigLayer},
-    ColliderCommand,
+    tracing, ColliderCommand,
 };
 use collider_common::{
-    miette::{Context, IntoDiagnostic, Result},
-    smol::fs,
+    miette::{self, Context, IntoDiagnostic, Result},
+    smol::{fs, process::Command},
 };
 use collider_electron::{Electron, ElectronOpts};
 
 #[derive(Debug, Clap, ColliderConfigLayer)]
 pub struct PackCmd {
     #[clap(
-        about = "Path to Electron app. Must be an index.js file, a folder containing a package.json file, a folder containing an index.json file, and .html/.htm file, or an http/https/file URL.",
+        about = "Path to Electron app. Must be an index.js file, a folder containing a package.json file, or a folder containing an index.json file, and .html/.htm file. URLs are not supported by this tool.",
         default_value = "."
     )]
-    path: String,
+    path: PathBuf,
 
     #[clap(
         about = "Directory to write packaged output files to.",
@@ -81,8 +81,78 @@ impl PackCmd {
         let dirname = electron_dir
             .file_name()
             .expect("BUG: This should have a file name.");
-        let build_dir = out.join("electron-builds").join(dirname).join("release");
-        let copied_electron = electron.copy_files(&build_dir).await?;
+        let build_dir = out.join("electron-builds").join(dirname);
+        let proj_dir = build_dir.join("project");
+        let copied_electron = electron.copy_files(&build_dir.join("release")).await?;
+        self.stage_proj(&self.path, &proj_dir).await?;
+        self.rebuild(&copied_electron).await?;
         Ok(copied_electron)
+    }
+
+    async fn rebuild(&self, electron: &Electron) -> Result<()> {
+        tracing::info!("Rebuilding node_modules for target platform.");
+        let npx_path = which::which("npx").into_diagnostic().context(
+            "Failed to find npx command while packaging project. NPM/npx are required by collider.",
+        )?;
+
+        let mut cmd = if cfg!(target_os = "windows") {
+            let mut cmd = Command::new("cmd");
+            cmd.arg("/c");
+            cmd.arg(npx_path);
+            cmd
+        } else {
+            Command::new(npx_path)
+        };
+
+        let status = cmd
+            .arg("electron-rebuild")
+            .arg("--arch")
+            .arg(electron.arch())
+            .arg("--platform")
+            .arg(electron.os())
+            .current_dir(&self.path)
+            .status()
+            .await
+            .into_diagnostic()
+            .context("Executing npx Command itself failed.")?;
+
+        if status.success() {
+            Ok(())
+        } else {
+            miette::bail!("node_modules rebuild failed.")
+        }
+    }
+
+    async fn stage_proj(&self, from: &Path, to: &Path) -> Result<()> {
+        let npm_path = which::which("npm").into_diagnostic().context(
+            "Failed to find npm command while packaging project. NPM/npx are required by collider.",
+        )?;
+        let mut cmd = if cfg!(target_os = "windows") {
+            let mut cmd = Command::new("cmd");
+            cmd.arg("/c");
+            cmd.arg(npm_path);
+            cmd
+        } else {
+            Command::new(npm_path)
+        };
+
+        let status = cmd
+            .arg("pack")
+            // TODO: This is an npm@7 feature. It's not gonna fly. We need
+            // to pack in-situ and move, but it's good enough for a
+            // prototype.
+            .arg("--pack-destination")
+            .arg(to)
+            .current_dir(from)
+            .status()
+            .await
+            .into_diagnostic()
+            .context("Executing npm Command itself failed.")?;
+
+        if status.success() {
+            Ok(())
+        } else {
+            miette::bail!("Project staging failed.")
+        }
     }
 }

--- a/commands/collider-cmd-pack/src/lib.rs
+++ b/commands/collider-cmd-pack/src/lib.rs
@@ -8,9 +8,11 @@ use collider_command::{
 };
 use collider_common::{
     miette::{self, Context, IntoDiagnostic, Result},
-    smol::{fs, process::Command},
+    smol::{self, fs, process::Command},
 };
 use collider_electron::{Electron, ElectronOpts};
+use flate2::read::GzDecoder;
+use tar::Archive;
 
 #[derive(Debug, Clap, ColliderConfigLayer)]
 pub struct PackCmd {
@@ -124,35 +126,105 @@ impl PackCmd {
     }
 
     async fn stage_proj(&self, from: &Path, to: &Path) -> Result<()> {
+        tracing::info!("Staging current app before packaging");
         let npm_path = which::which("npm").into_diagnostic().context(
             "Failed to find npm command while packaging project. NPM/npx are required by collider.",
         )?;
+        tracing::debug!("npm path: {}", npm_path.display());
+
+        // First, we stage the current app into the staging folder by packing
+        // it and re-extracting it. This gets rid of unneeded crud.
+        tracing::debug!("Packing Electron project at {}", from.display());
         let mut cmd = if cfg!(target_os = "windows") {
             let mut cmd = Command::new("cmd");
             cmd.arg("/c");
-            cmd.arg(npm_path);
+            cmd.arg(&npm_path);
             cmd
         } else {
-            Command::new(npm_path)
+            Command::new(&npm_path)
         };
-
-        let status = cmd
+        let output = cmd
             .arg("pack")
-            // TODO: This is an npm@7 feature. It's not gonna fly. We need
-            // to pack in-situ and move, but it's good enough for a
-            // prototype.
-            .arg("--pack-destination")
-            .arg(to)
             .current_dir(from)
+            .output()
+            .await
+            .into_diagnostic()
+            .context("Spawning npm pack Command itself failed.")?;
+
+        if !output.status.success() {
+            miette::bail!("packing app for staging failed.")
+        }
+
+        // Now that we packed, we need to extract the tarball into the staging directory and remove the tarball.
+        let tarball_name = String::from_utf8(output.stdout)
+            .into_diagnostic()
+            .context("Failed to parse staging tarball filename as utf8. This is probably a bug in NPM itself.")?;
+        let tarball = from.join(&tarball_name.trim());
+        let to_clone = to.to_owned();
+        tracing::debug!(
+            "Extracting packed NPM project from {} to {}",
+            tarball.display(),
+            to.display()
+        );
+        smol::unblock(move || {
+            // TODO: error handling
+            let mut ar = Archive::new(GzDecoder::new(
+                std::fs::File::open(&tarball).expect("BUG: Where did the tarball go?"),
+            ));
+            ar.unpack(&to_clone)
+        })
+        .await
+        .into_diagnostic()
+        .context("Failed to extract staging tarball.")?;
+
+        let from_nm = from.join("node_modules");
+        let to_nm = to.join("node_modules");
+        tracing::debug!(
+            "Copying node_modules folder from {} to {}",
+            from_nm.display(),
+            to_nm.display()
+        );
+        fs::create_dir_all(&to_nm)
+            .await
+            .into_diagnostic()
+            .context("Failed to create destination directory for copied node_modules in staging")?;
+        smol::unblock(move || {
+            let mut opts = fs_extra::dir::CopyOptions::new();
+            opts.overwrite = true;
+            opts.content_only = true;
+            fs_extra::dir::copy(from_nm, to_nm, &opts)
+        })
+        .await
+        .into_diagnostic()
+        .context("Failed to copy over node_modules")?;
+
+        // Once we've moved node_modules, we do a prune and a rebuild.
+        tracing::debug!(
+            "Pruning node_modules directory at {}",
+            to.join("node_modules").display()
+        );
+        let mut cmd = if cfg!(target_os = "windows") {
+            let mut cmd = Command::new("cmd");
+            cmd.arg("/c");
+            cmd.arg(&npm_path);
+            cmd
+        } else {
+            Command::new(&npm_path)
+        };
+        let status = cmd
+            .arg("prune")
+            .arg("--omit")
+            .arg("dev")
+            .current_dir(to)
             .status()
             .await
             .into_diagnostic()
-            .context("Executing npm Command itself failed.")?;
+            .context("Spawning npm Command itself failed.")?;
 
-        if status.success() {
-            Ok(())
-        } else {
-            miette::bail!("Project staging failed.")
+        if !status.success() {
+            miette::bail!("pruning staging folder failed.")
         }
+
+        Ok(())
     }
 }

--- a/commands/collider-cmd-start/src/lib.rs
+++ b/commands/collider-cmd-start/src/lib.rs
@@ -8,11 +8,10 @@ use collider_command::{
 };
 use collider_common::{
     miette::{Context, Result},
-    serde::Deserialize,
     smol::process::Command,
 };
 use collider_electron::ElectronOpts;
-use node_semver::{Range, Version};
+use node_semver::Range;
 
 pub use errors::StartError;
 

--- a/commands/collider-cmd-start/src/lib.rs
+++ b/commands/collider-cmd-start/src/lib.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use collider_command::{
     async_trait::async_trait,
@@ -24,7 +24,7 @@ pub struct StartCmd {
         about = "Path to Electron app. Must be an index.js file, a folder containing a package.json file, a folder containing an index.json file, and .html/.htm file, or an http/https/file URL.",
         default_value = "."
     )]
-    path: PathBuf,
+    path: String,
 
     #[clap(long, short, about = "Force download of the Electron binary.")]
     force: bool,

--- a/crates/collider-electron/src/lib.rs
+++ b/crates/collider-electron/src/lib.rs
@@ -21,6 +21,7 @@ struct PackageJson {
     version: Version,
 }
 
+#[derive(Debug, Clone)]
 pub struct Electron {
     exe: PathBuf,
     version: Version,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
-  "//": "This is a dummy package for interactive collider dev. In practice, this would be the JS wrapper's package.json",
   "name": "collider",
-  "version": "13.0.0"
+  "version": "13.0.0",
+  "dependencies": {
+    "electron-rebuild": "^3.2.3"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "collider",
   "version": "13.0.0",
   "dependencies": {
+    "asar": "^3.1.0",
     "electron-rebuild": "^3.2.3"
   }
 }


### PR DESCRIPTION
This fills out the `collider pack` command and adds rudimentary support for packaging apps into installers.